### PR TITLE
Only load required functions in each case

### DIFF
--- a/lib/puppet/parser/functions/pdbfactquery.rb
+++ b/lib/puppet/parser/functions/pdbfactquery.rb
@@ -10,7 +10,7 @@ module Puppet::Parser::Functions
     pdbfactquery('foo.example.com')
     # Get the uptime fact for foo.example.com
     pdbfactquery('foo.example.com', 'uptime')") do |args|
-    Puppet::Parser::Functions.autoloader.loadall
+    Puppet::Parser::Functions.autoloader.load(:pdbquery) unless Puppet::Parser::Functions.autoloader.loaded?(:pdbquery)
 
     if args[0].is_a?(Array) then
       if args.length > 1 then

--- a/lib/puppet/parser/functions/pdbnodequery.rb
+++ b/lib/puppet/parser/functions/pdbnodequery.rb
@@ -22,7 +22,8 @@ module Puppet::Parser::Functions
         ['=',['node','active'],true],
         ['=','type','Class'],
         ['=','title','Apache']])") do |args|
-    Puppet::Parser::Functions.autoloader.loadall
+    Puppet::Parser::Functions.autoloader.load(:pdbquery) unless Puppet::Parser::Functions.autoloader.loaded?(:pdbquery)
+    Puppet::Parser::Functions.autoloader.load(:pdbresourcequery) unless Puppet::Parser::Functions.autoloader.loaded?(:pdbresourcequery)
 
     nodeqnodes = function_pdbquery(['nodes', args[0]])
 

--- a/lib/puppet/parser/functions/pdbresourcequery.rb
+++ b/lib/puppet/parser/functions/pdbresourcequery.rb
@@ -20,7 +20,7 @@ module Puppet::Parser::Functions
         ['=',['node','active'],true],
         ['=','type','File'],
         ['=',['parameter','owner'],'root']], 'certname')") do |args|
-    Puppet::Parser::Functions.autoloader.loadall
+    Puppet::Parser::Functions.autoloader.load(:pdbquery) unless Puppet::Parser::Functions.autoloader.loaded?(:pdbquery)
 
     ret = function_pdbquery(['resources', args[0]])
     if args.length > 1 then

--- a/lib/puppet/parser/functions/pdbstatusquery.rb
+++ b/lib/puppet/parser/functions/pdbstatusquery.rb
@@ -11,7 +11,7 @@ module Puppet::Parser::Functions
     pdbstatusquery('foo.example.com')
     # Get catalog_timestamp for foo.example.com
     pdbstatusquery('foo.example.com', 'catalog_timestamp')") do |args|
-    Puppet::Parser::Functions.autoloader.loadall
+    Puppet::Parser::Functions.autoloader.load(:pdbquery) unless Puppet::Parser::Functions.autoloader.loaded?(:pdbquery)
 
     ret = function_pdbquery(["status/nodes/#{args[0]}"])
     if args.length > 1 then


### PR DESCRIPTION
Just updated the autoloader to only load the required functions in each function - there's a minor performance gain, and all the world of pain avoided in the event that one happens to have functions available that I don't have all the toys for....
