### PR TITLE
Fix issue with query_facts returning empty hash

### DIFF
--- a/lib/puppet/parser/functions/query_facts.rb
+++ b/lib/puppet/parser/functions/query_facts.rb
@@ -20,8 +20,6 @@ EOT
   require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'puppetdb/connection'))
 
   puppetdb = PuppetDB::Connection.new(Puppet::Util::Puppetdb.server, Puppet::Util::Puppetdb.port)
-  if query.is_a? String then
-    query = puppetdb.parse_query query
-  end
+  query = puppetdb.parse_query query, :facts if query.is_a? String
   puppetdb.facts(facts, query)
 end


### PR DESCRIPTION
`query_facts("Class[Edge::node] and dc=\"${::dc}\"", ['ipaddress','shard'])`
results in empty hash

`query_nodes("Class[Edge::node] and dc=\"${::dc}\"")`
results in correctly outputted node names

Fix is to make sure to pass `:facts` to puppetdb.parse_query like query_nodes does.

:thumbsup: 
