### PR TITLE
Improves formatting of the node_info display

### DIFF
--- a/lib/puppet/face/query.rb
+++ b/lib/puppet/face/query.rb
@@ -66,10 +66,11 @@ Puppet::Face.define(:query, '1.0.0') do
     when_invoked do |query, options|
       puppetdb = PuppetDB::Connection.new options[:puppetdb_host], options[:puppetdb_port]
       nodes = puppetdb.query(:nodes, puppetdb.parse_query(query, :nodes))
+
       if options[:node_info]
-        nodes
+        Hash[nodes.collect { |node| [node['name'], node.reject{|k,v| k == "name"}] }]
       else
-        nodes.collect { |node| node['name'] } unless options[:node_info]
+        nodes.collect { |node| node['name'] }
       end
     end
 


### PR DESCRIPTION
Previously the node info display would just to_s the data resulting
in a output like this:

   catalog_timestamp2013-11-07T10:43:25.989Zreport_timestampdeactivatednamedomu-12-x-x-x-x-x.compute-1.internalfacts_timestamp2013-11-07T10:43:22.882Z

This commit tweaks the output so it's the same as the one from the
facts command:

   domu-x-x-x-x-x-x.compute-1.internal {"facts_timestamp":"2013-11-07T10:43:22.882Z","catalog_timestamp":"2013-11-07T10:43:25.989Z","deactivated":null,"report_timestamp":null}

Of course this will also change the data format of anyone using the
face so up to you to take this commit, but this is both more consistant
between the different actions and more readable on the cli
