### PR TITLE
idempotency fix: sort results when using query facts in hiera

### DIFF
--- a/lib/hiera/backend/puppetdb_backend.rb
+++ b/lib/hiera/backend/puppetdb_backend.rb
@@ -40,7 +40,7 @@ class Hiera
 
           if fact then
             query = @puppetdb.parse_query query, :facts if query.is_a? String
-            @puppetdb.facts([fact], query).each_value.collect { |facts| facts[fact] }
+            @puppetdb.facts([fact], query).each_value.collect { |facts| facts[fact] }.sort
           else
             query = @puppetdb.parse_query query, :nodes if query.is_a? String
             @puppetdb.query(:nodes, query).collect { |n| n['name'] }

--- a/ruby-puppetdb.gemspec
+++ b/ruby-puppetdb.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'racc', '~>1.4', '<1.4.12'
   s.add_development_dependency 'rexical'
   s.add_development_dependency 'puppet-blacksmith', '~>3.0'
+  s.add_development_dependency 'mime-types', '< 2.0.0' if RUBY_VERSION < "1.9.0"
+  s.add_development_dependency 'rest-client', '< 1.7.0' if RUBY_VERSION < "1.9.0"
 end


### PR DESCRIPTION
Could you consider merge following fix for non idempotent behaviour. Querying facts in hiera results come is random order what time to time creates new catalog:

data in hiera
ntp::servers::_nodequery": [ "Class[Ntp] and Class[Wg::Mgmt] and site=%{::site}","ipaddress" ],

agent log
2014-12-03T07:03:27.280062+00:00 node-80 puppet-agent[2298]: Finished catalog run in 33.38 seconds$
2014-12-03T07:33:18.488357+00:00 node-80 puppet-agent[7474]: Finished catalog run in 25.88 seconds$
2014-12-03T08:03:26.849164+00:00 node-80 puppet-agent[12568]: Finished catalog run in 34.13 seconds$
2014-12-03T08:33:03.129171+00:00 node-80 puppet-agent[17674]: (/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content) content changed '{md5}782b57b2f5107f7c3d5da0a4ca989b0c' to '{
md5}b27965b24a7b6d95de07c5752fdb7947'$
2014-12-03T08:33:19.009255+00:00 node-80 puppet-agent[17674]: (/Stage[main]/Ntp::Service/Service[ntp]) Triggered 'refresh' from 1 events$
2014-12-03T08:33:34.410194+00:00 node-80 puppet-agent[17674]: Finished catalog run in 40.86 seconds$
2014-12-03T09:03:11.120723+00:00 node-80 puppet-agent[22807]: (/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content) content changed '{md5}b27965b24a7b6d95de07c5752fdb7947' to '{
md5}782b57b2f5107f7c3d5da0a4ca989b0c'$
2014-12-03T09:03:22.008948+00:00 node-80 puppet-agent[22807]: (/Stage[main]/Ntp::Service/Service[ntp]) Triggered 'refresh' from 1 events$
2014-12-03T09:03:38.083029+00:00 node-80 puppet-agent[22807]: Finished catalog run in 43.00 seconds$
2014-12-03T09:33:02.539291+00:00 node-80 puppet-agent[27943]: (/Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content) content changed '{md5}782b57b2f5107f7c3d5da0a4ca989b0c' to '{md5}b27965b24a7b6d95de07c5752fdb7947'$
.....