### PR TITLE
Adding a group by hosts option for query_resources

### DIFF
--- a/lib/puppet/parser/functions/query_resources.rb
+++ b/lib/puppet/parser/functions/query_resources.rb
@@ -1,12 +1,14 @@
-Puppet::Parser::Functions.newfunction(:query_resources, :type => :rvalue, :arity => 2, :doc => <<-EOT
+Puppet::Parser::Functions.newfunction(:query_resources, :type => :rvalue, :arity => -3, :doc => <<-EOT
 
-  Accepts two arguments: a query used to discover nodes, and a
+  Accepts two or three arguments: a query used to discover nodes, a
   resource query for the resources that should be returned from
-  those hosts.
+  those hosts, and optionally a boolean for whether or not to group the results by host.
 
-  The result is a hash that maps the name of the nodes to a list of
+  The result is a hash (by default) that maps the name of the nodes to a list of
   resource entries.  This is a list because there's no single
   reliable key for resource operations that's of any use to the end user.
+
+  If the third parameters is false the result will be a an array of all resources found.
 
   Examples:
 
@@ -22,9 +24,13 @@ Puppet::Parser::Functions.newfunction(:query_resources, :type => :rvalue, :arity
 
       query_resources(false, 'Class["apache"]')
 
+    Returns the parameters for the apache class for all nodes in a flat array:
+
+      query_resources(false, 'Class["apache"]', false)
+
 EOT
 ) do |args|
-  nodequery, resquery = args
+  nodequery, resquery, grouphosts = args
 
   require 'puppet/util/puppetdb'
   # This is needed if the puppetdb library isn't pluginsynced to the master
@@ -38,5 +44,5 @@ EOT
   puppetdb = PuppetDB::Connection.new(Puppet::Util::Puppetdb.server, Puppet::Util::Puppetdb.port)
   nodequery = puppetdb.parse_query nodequery, :facts if nodequery and nodequery.is_a? String and ! nodequery.empty?
   resquery = puppetdb.parse_query resquery, :none if resquery and resquery.is_a? String and ! resquery.empty?
-  return puppetdb.resources(nodequery, resquery)
+  return puppetdb.resources(nodequery, resquery, nil, grouphosts)
 end

--- a/lib/puppetdb/connection.rb
+++ b/lib/puppetdb/connection.rb
@@ -51,8 +51,9 @@ class PuppetDB::Connection
   #
   # @param resquery [Array] a resources query for what resources to fetch
   # @param nodequery [Array] the query to find the nodes to fetch resources for, optionally empty
-  # @return [Hash] a hash of hashes with resources for each node mathing query
-  def resources(nodequery, resquery, http=nil)
+  # @param grouphosts [Boolean] whether or not to group the results by the host they belong to
+  # @return [Hash|Array] a hash of hashes with resources for each node mathing query or array if grouphosts was false
+  def resources(nodequery, resquery, http=nil, grouphosts=true)
     if resquery and ! resquery.empty?
       if nodequery and ! nodequery.empty?
         q = ['and', resquery, nodequery]
@@ -63,12 +64,19 @@ class PuppetDB::Connection
       raise RuntimeError, "PuppetDB resources query error: at least one argument must be non empty; arguments were: nodequery: #{nodequery.inspect} and requery: #{resquery.inspect}"
     end
     resources = {}
-    query(:resources, q, http).each do |resource|
-      unless resources.has_key? resource['certname']
-        resources[resource['certname']] = []
+    results = query(:resources, q, http)
+
+    if grouphosts
+      results.each do |resource|
+        unless resources.has_key? resource['certname']
+          resources[resource['certname']] = []
+        end
+        resources[resource['certname']] << resource
       end
-      resources[resource['certname']] << resource
+    else
+      resources = results
     end
+
     return resources
   end
 


### PR DESCRIPTION
This patch makes it possible to get a flat array of matching resources which make it far easier to work with directly.