### PR TITLE
Query tag

### DIFF
--- a/lib/puppetdb/astnode.rb
+++ b/lib/puppetdb/astnode.rb
@@ -72,7 +72,13 @@ class PuppetDB::ASTNode
       when :nodes,:facts # Do a subquery to match nodes matching the facts
         return subquery(mode, :facts, ['and', ['=', 'name', @children[0].evaluate(mode)], [op, 'value', @children[1].evaluate(mode)]])
       when :resources
-        return [op, ['parameter', @children[0].evaluate(mode)], @children[1].evaluate(mode)]
+        paramname = @children[0].evaluate(mode)
+        case paramname
+        when "tag"
+          return [op, paramname, @children[1].evaluate(mode)]
+        else
+          return [op, ['parameter', paramname], @children[1].evaluate(mode)]
+        end
       end
     when :string
       return @value.to_s

--- a/lib/puppetdb/connection.rb
+++ b/lib/puppetdb/connection.rb
@@ -4,6 +4,9 @@ class PuppetDB::Connection
   require 'rubygems'
   require 'puppetdb/parser'
   require 'uri'
+  require 'puppet/util/logging'
+
+  include Puppet::Util::Logging
 
   def initialize(host='puppetdb', port=443, use_ssl=true)
     @host = host
@@ -88,6 +91,8 @@ class PuppetDB::Connection
 
     uri = "/#{version}/#{endpoint}"
     uri += URI.escape "?query=#{query.to_json}" unless query.nil? || query.empty?
+
+    debug("PuppetDB query: #{query.to_json}")
 
     resp = http.get(uri, headers)
     raise "PuppetDB query error: [#{resp.code}] #{resp.msg}, query: #{query.to_json}" unless resp.kind_of?(Net::HTTPSuccess)

--- a/spec/unit/puppetdb/connection_spec.rb
+++ b/spec/unit/puppetdb/connection_spec.rb
@@ -43,6 +43,10 @@ describe PuppetDB::Connection do
       connection.parse_query('file[foo]{bar=baz}').should eq ["in", "name", ["extract", "certname", ["select-resources", ["and", ["=", "exported", false], ["=", "type", "File"], ["=", "title", "foo"], ["=", ["parameter", "bar"], "baz"]]]]]
     end
 
+    it "should parse resource queries with tags" do
+      connection.parse_query('file[foo]{tag=baz}').should eq ["in", "name", ["extract", "certname", ["select-resources", ["and", ["=", "exported", false], ["=", "type", "File"], ["=", "title", "foo"], ["=", "tag", "baz"]]]]]
+    end
+
     it "should handle precedence within resource parameter queries" do
       connection.parse_query('{foo=1 or bar=2 and baz=3}').should eq ["in", "name", ["extract", "certname", ["select-resources", ["and", ["=", "exported", false], ["or", ["=", ["parameter", "foo"], 1], ["and", ["=", ["parameter", "bar"], 2], ["=", ["parameter", "baz"], 3]]]]]]]
       connection.parse_query('{(foo=1 or bar=2) and baz=3}').should eq ["in", "name", ["extract", "certname", ["select-resources", ["and", ["=", "exported", false], ["or", ["=", ["parameter", "foo"], 1], ["=", ["parameter", "bar"], 2]], ["=", ["parameter", "baz"], 3]]]]]


### PR DESCRIPTION
This implements #41, allowing you to query for nodes by a resource's tag.

    Class[Profile::Elasticsearch] { tag="cluster_xyz" }

Let me know if the addition of the debug logging is objectionable and I can take that out.

Thanks