### PR TITLE
We still need pdbquery.rb

### DIFF
--- a/lib/puppet/parser/functions/pdbquery.rb
+++ b/lib/puppet/parser/functions/pdbquery.rb
@@ -31,7 +31,7 @@ module Puppet::Parser::Functions
     end
 
     conn = Puppet::Network::HttpPool.http_instance(Puppet::Util::Puppetdb.server, Puppet::Util::Puppetdb.port, use_ssl = true)
-    response = conn.get("/v1/#{t}#{params}", { "Accept" => "application/json",})
+    response = conn.get("/v3/#{t}#{params}", { "Accept" => "application/json",})
 
     unless response.kind_of?(Net::HTTPSuccess)
       raise Puppet::ParseError, "PuppetDB query error: [#{response.code}] #{response.msg}"


### PR DESCRIPTION
As far as I can tell query_nodes.rb and query_facts.rb do not provided resource parameters to us.  So I have simply updated pdbquery.rb to support puppetdb API v3.

Example:

pdbresourcequery(['and',['=', 'type', 'Nfs::Server::Export::Configure'],['not',['=', 'tag', 'undef']]])
I needed 'certname => ...' tag => ...' and 'title => ...' out of it so that I can build some autofs tables with it as well as some other stuff.   I'm unable to see a way to do this with query_nodes and query_facts.  Feel free to correct me if denying this pull request.

Thanks.