### PR TITLE
(#39) Change from 'experimental' to 'v3' interface

### DIFF
--- a/lib/puppet/face/query.rb
+++ b/lib/puppet/face/query.rb
@@ -123,7 +123,7 @@ Puppet::Face.define(:query, '1.0.0') do
       nodes.each_slice(20) do |nodeslice|
         eventquery = ['and', ['>', 'timestamp', starttime], ['<', 'timestamp', endtime], ['or', *nodeslice.collect { |n| ['=', 'certname', n]}]]
         eventquery << ['=', 'status', options[:status]] if options[:status] != 'all'
-        events.concat puppetdb.query(:events, eventquery, nil, :experimental)
+        events.concat puppetdb.query(:events, eventquery, nil, :v3)
       end
 
       events.sort_by do |e|


### PR DESCRIPTION
This migrates from the 'experimental' interface to the 'v3' interface
for the 'puppet query' Face.

Having 'experimental' in place was causing 404 errors to be thrown when
attempting to query PuppetDB via the Face.