### PR TITLE
Fixes wrong variable name in *query nodes*

### DIFF
--- a/lib/puppet/face/query.rb
+++ b/lib/puppet/face/query.rb
@@ -67,7 +67,7 @@ Puppet::Face.define(:query, '1.0.0') do
     end
 
     when_invoked do |query, options|
-      puppetdb = PuppetDB::Connection.new options[:puppetdb_host], options[:puppetdb_port], !options[:no_ssl]
+      puppetdb = PuppetDB::Connection.new options[:host], options[:port], !options[:no_ssl]
       parser = PuppetDB::Parser.new
       nodes = puppetdb.query(:nodes, parser.parse(query, :nodes))
 


### PR DESCRIPTION
* Old variable name `puppetdb_{host,port}` was still used and breaks the master branch