### PR TITLE
Fix server selection in puppet face

### DIFF
--- a/lib/puppet/application/query.rb
+++ b/lib/puppet/application/query.rb
@@ -6,8 +6,10 @@ class Puppet::Application::Query < Puppet::Application::FaceBase
     begin
       require 'puppet'
       require 'puppet/util/puppetdb'
-      host = Puppet::Util::Puppetdb.server || 'puppetdb'
-      port = Puppet::Util::Puppetdb.port || 8081
+      PuppetDB::Connection.check_version
+      uri = URI(Puppet::Util::Puppetdb.config.server_urls.first)
+      host = uri.host || 'puppetdb'
+      port = uri.port || 8081
     rescue Exception => e
       Puppet.debug(e.message)
       host = 'puppetdb'


### PR DESCRIPTION
Copy @pyther's approach to getting the current puppetdb server host and port. The face defaults to the "puppetdb" server without this.

This is intended to work in conjunction with PR https://github.com/dalen/puppet-puppetdbquery/pull/62, so it should probably be merged afterward. Without this change the puppet face doesn't work properly on puppet 4.