### PR TITLE
Bug/68 query facts missing method

### DIFF
--- a/lib/puppet/parser/functions/query_facts.rb
+++ b/lib/puppet/parser/functions/query_facts.rb
@@ -32,5 +32,5 @@ EOT
   puppetdb = PuppetDB::Connection.new(uri.host, uri.port)
   parser = PuppetDB::Parser.new
   query = parser.parse query, :facts if query.is_a? String
-  puppetdb.facts(facts, query)
+  puppetdb.query(facts, query)
 end

--- a/lib/puppet/parser/functions/query_facts.rb
+++ b/lib/puppet/parser/functions/query_facts.rb
@@ -31,6 +31,6 @@ EOT
   uri = URI(Puppet::Util::Puppetdb.config.server_urls.first)
   puppetdb = PuppetDB::Connection.new(uri.host, uri.port)
   parser = PuppetDB::Parser.new
-  query = parser.parse query, :facts if query.is_a? String
-  puppetdb.query(facts, query)
+  query = parser.facts_query query, facts if query.is_a? String
+  puppetdb.query(:facts, query)
 end


### PR DESCRIPTION
This Pull Request adresses a bug I opened (#68) in which the query_facts function was invalidly calling an old and now missing method, facts from PuppetDB::Connection. I have this working with test entries in my environment.

fixes #68 