### PR TITLE
Fix query syntax in facts call

### DIFF
--- a/lib/puppet/face/query.rb
+++ b/lib/puppet/face/query.rb
@@ -47,8 +47,12 @@ Puppet::Face.define(:query, '1.0.0') do
     when_invoked do |query, options|
       puppetdb = PuppetDB::Connection.new options[:host], options[:port], !options[:no_ssl]
       parser = PuppetDB::Parser.new
-      factquery = parser.facts_query(query, options[:facts].split(','))
-      parser.facts_hash(puppetdb.query(factquery))
+      if options[:facts] != ''
+        factquery = parser.facts_query(query, options[:facts].split(','))
+      else
+        factquery = parser.parse(query, :facts)
+      end
+      parser.facts_hash(puppetdb.query(:facts, factquery))
     end
   end
 


### PR DESCRIPTION
This PR references issue #67 in which the puppet query face facts throws a 400. Found an issue where the query endpoint was missing from the call and also that the facts option for the face was being treated as non-optional causing the wrong query builld.

fixes #67 