### PR TITLE
parser_helper.rb, allow matching facts by regular expression

### DIFF
--- a/lib/puppetdb/parser_helper.rb
+++ b/lib/puppetdb/parser_helper.rb
@@ -22,7 +22,13 @@ module PuppetDB::ParserHelper
     if facts.nil?
       nodequery
     else
-      factquery = ['or', *facts.collect { |f| ['=', 'name', f] }]
+      factquery = ['or', *facts.collect { |f|
+         if (f =~ /^\/(.+)\/$/)
+            ['~', 'name', f.scan(/^\/(.+)\/$/).last.first]
+         else
+            ['=', 'name', f]
+         end
+      }]
       if nodequery
         ['and', nodequery, factquery]
       else


### PR DESCRIPTION
(just opening a new pull request instead of #57 to direct request to branch filter-facts-by-regexp instead of master)

I'm not sure if this is the best way of doing it. But I needed a way to return facts from PuppetDB without knowing how many of them are actually there.

In my situation it's about the "ipaddress_*" facts stored in PuppetDB - to retrieve all IP addresses associated with a node.

The PuppetDB query that is normally generated on query_facts() queries PuppetDB with a "=" to match a fact.
I changed it so that if it detects an regular expression (^/(.+)/$) in the queries fact field, it will use a "~" in the resulting PuppetDB query.