### PR TITLE
Support querying for nested facts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Unreleased:
+- Support querying for nested keys inside of facts
+
 2.1.1:
 - Send datetimes in ISO8601 variant that PuppetDB can handle. (#81)
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Returns an array of certnames or fact values if a fact is specified.
 
     $hosts = query_nodes('manufacturer~"Dell.*" and processorcount=24 and Class[Apache]')
 
-    $hostips = query_nodes('manufacturer~"Dell.*" and processorcount=24 and Class[Apache]', ipaddress)
+    $hostips = query_nodes('manufacturer~"Dell.*" and processorcount=24 and Class[Apache]', 'ipaddress')
 
 ### query_resources
 
@@ -201,6 +201,17 @@ Example return value in JSON format:
         "osfamily": "Debian"
       }
     }
+
+### Querying nested facts
+
+Facter 3 introduced many nested facts, so puppetdbquery provides an easy way to query for a value nested within a fact that's a hash.
+To query for a nested value, simply pass an array of keys as a fact value, rather than just a string.
+
+#### Example
+
+    $host_eth0_networks = query_nodes('manufacturer~"Dell.*" and Class[Apache]', ['networking', 'interfaces', 'eth0', 'network'])
+
+    $host_kernels_and_ips = query_facts('manufacturer~"Dell.*" and Class[Apache]', ['kernel', ['networking', 'interfaces', 'eth1', 'ip']])
 
 Hiera backend
 -------------

--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ Example return value in JSON format:
 ### Querying nested facts
 
 Facter 3 introduced many nested facts, so puppetdbquery provides an easy way to query for a value nested within a fact that's a hash.
-To query for a nested value, simply pass an array of keys as a fact value, rather than just a string.
+To query for a nested value, simply join the keys you want to extract together on periods, like so:
 
 #### Example
 
-    $host_eth0_networks = query_nodes('manufacturer~"Dell.*" and Class[Apache]', ['networking', 'interfaces', 'eth0', 'network'])
+    $host_eth0_networks = query_nodes('manufacturer~"Dell.*" and Class[Apache]', 'networking.interfaces.eth0.network')
 
-    $host_kernels_and_ips = query_facts('manufacturer~"Dell.*" and Class[Apache]', ['kernel', ['networking', 'interfaces', 'eth1', 'ip']])
+    $host_kernels_and_ips = query_facts('manufacturer~"Dell.*" and Class[Apache]', ['kernel', 'networking.interfaces.eth1.ip'])
 
 Hiera backend
 -------------

--- a/lib/puppet/face/query.rb
+++ b/lib/puppet/face/query.rb
@@ -48,11 +48,13 @@ Puppet::Face.define(:query, '1.0.0') do
       puppetdb = PuppetDB::Connection.new options[:host], options[:port], !options[:no_ssl]
       parser = PuppetDB::Parser.new
       if options[:facts] != ''
-        factquery = parser.facts_query(query, options[:facts].split(','))
+        facts = options[:facts].split(',')
+        factquery = parser.facts_query(query, facts)
       else
+        facts = [:all]
         factquery = parser.parse(query, :facts)
       end
-      parser.facts_hash(puppetdb.query(:facts, factquery, :extract => [:certname, :name, :value]))
+      parser.facts_hash(puppetdb.query(:facts, factquery, :extract => [:certname, :name, :value]), facts)
     end
   end
 

--- a/lib/puppet/parser/functions/query_facts.rb
+++ b/lib/puppet/parser/functions/query_facts.rb
@@ -15,6 +15,7 @@ Puppet::Parser::Functions.newfunction(:query_facts, :type => :rvalue, :arity => 
 EOT
                                      ) do |args|
   query, facts = args
+  facts = facts.map { |fact| fact.match(/\./) ? fact.split('.') : fact }
   facts_for_query = facts.map { |fact| fact.is_a?(Array) ? fact.first : fact }
 
   require 'puppet/util/puppetdb'

--- a/lib/puppet/parser/functions/query_facts.rb
+++ b/lib/puppet/parser/functions/query_facts.rb
@@ -15,6 +15,7 @@ Puppet::Parser::Functions.newfunction(:query_facts, :type => :rvalue, :arity => 
 EOT
                                      ) do |args|
   query, facts = args
+  facts_for_query = facts.map { |fact| fact.is_a?(Array) ? fact.first : fact }
 
   require 'puppet/util/puppetdb'
 
@@ -31,6 +32,6 @@ EOT
   uri = URI(Puppet::Util::Puppetdb.config.server_urls.first)
   puppetdb = PuppetDB::Connection.new(uri.host, uri.port, uri.scheme == 'https')
   parser = PuppetDB::Parser.new
-  query = parser.facts_query query, facts if query.is_a? String
-  parser.facts_hash(puppetdb.query(:facts, query, :extract => [:certname, :name, :value]))
+  query = parser.facts_query query, facts_for_query if query.is_a? String
+  parser.facts_hash(puppetdb.query(:facts, query, :extract => [:certname, :name, :value]), facts)
 end

--- a/lib/puppet/parser/functions/query_nodes.rb
+++ b/lib/puppet/parser/functions/query_nodes.rb
@@ -1,19 +1,23 @@
 Puppet::Parser::Functions.newfunction(:query_nodes, :type => :rvalue, :arity => -2, :doc => <<-EOT
 
-  accepts two arguments, a query used to discover nodes, and a optional
+  accepts two arguments, a query used to discover nodes, and an optional
   fact that should be returned.
 
   The query specified should conform to the following format:
     (Type[title] and fact_name<operator>fact_value) or ...
     Package["mysql-server"] and cluster_id=my_first_cluster
 
-  The second argument should be single fact or array of nested facts
+  The second argument should be single fact or series of keys joined on periods
   (this argument is optional)
 
 EOT
                                      ) do |args|
   query, fact = args
-  fact_for_query = fact.is_a?(Array) ? fact.shift : fact
+  fact_for_query = if fact && fact.match(/\./)
+                     fact.split('.').first
+                   else
+                     fact
+                   end
 
   require 'puppet/util/puppetdb'
 
@@ -34,8 +38,8 @@ EOT
     query = parser.facts_query(query, [fact_for_query])
     response = puppetdb.query(:facts, query, :extract => :value)
 
-    if fact.is_a?(Array)
-      parser.extract_nested_fact(response, fact)
+    if fact.split('.').size > 1
+      parser.extract_nested_fact(response, fact.split('.')[1..-1])
     else
       response.collect { |f| f['value'] }
     end

--- a/lib/puppetdb/parser_helper.rb
+++ b/lib/puppetdb/parser_helper.rb
@@ -77,11 +77,13 @@ module PuppetDB::ParserHelper
       hash = fact_hash['value']
 
       # Traverse the hash, setting `hash` equal to the next level deep each step
-      keys.each do |key|
-        hash = hash[key]
+      keys[0..-2].each do |key|
+        hash = hash.fetch(key, {})
       end
 
-      hash
+      # Lookup the final key. This will convert to nil if we've been defaulting
+      # to empty hash beforehand.
+      hash[keys.last]
     end
   end
 

--- a/lib/puppetdb/parser_helper.rb
+++ b/lib/puppetdb/parser_helper.rb
@@ -40,7 +40,7 @@ module PuppetDB::ParserHelper
     fact_hash.reduce({}) do |ret, fact|
       # Array#include? only matches on values of the same type, so if we find
       # a matching string, it's not a nested query.
-      name, value = if facts.include?(fact['name'])
+      name, value = if facts.include?(fact['name']) || facts == [:all]
                       [fact['name'], fact['value']]
                     else
                       # Find the set of keys where the first value is the fact name

--- a/lib/puppetdb/parser_helper.rb
+++ b/lib/puppetdb/parser_helper.rb
@@ -33,16 +33,55 @@ module PuppetDB::ParserHelper
 
   # Turn an array of facts into a hash of nodes containing facts
   #
-  # @param facts [Array] fact values
+  # @param fact_hash [Array] fact values
+  # @param facts [Array] fact names
   # @return [Hash] nodes as keys containing a hash of facts as value
-  def facts_hash(facts)
-    facts.reduce({}) do |ret, fact|
+  def facts_hash(fact_hash, facts)
+    fact_hash.reduce({}) do |ret, fact|
+      # Array#include? only matches on values of the same type, so if we find
+      # a matching string, it's not a nested query.
+      name, value = if facts.include?(fact['name'])
+                [fact['name'], fact['value']]
+              else
+                # Find the set of keys where the first value is the fact name
+                nested_keys = facts.select do |x|
+                  x.is_a?(Array) && x.first == fact['name']
+                end.flatten
+
+                # Join all the key names together with an underscore to give
+                # us a unique name, and then send all the keys but the fact
+                # name (which was already queried out) to extract_nested_fact
+                [
+                  nested_keys.join("_"),
+                  extract_nested_fact([fact], nested_keys[1..-1]).first
+                ]
+              end
+
       if ret.include? fact['certname']
-        ret[fact['certname']][fact['name']] = fact['value']
+        ret[fact['certname']][name] = value
       else
-        ret[fact['certname']] = { fact['name'] => fact['value'] }
+        ret[fact['certname']] = { name => value }
       end
       ret
+    end
+  end
+
+  # Take an array of hashes of fact hashes and get a nested value from each
+  # of them.
+  #
+  # @param fact_hashes [Array] an array of hashes of fact hashes
+  # @param keys [Array] an array of keys to dig into the hash
+  # @returt [Array] an array of extracted values
+  def extract_nested_fact(fact_hashes, keys)
+    fact_hashes.map do |fact_hash|
+      hash = fact_hash['value']
+
+      # Traverse the hash, setting `hash` equal to the next level deep each step
+      keys.each do |key|
+        hash = hash[key]
+      end
+
+      hash
     end
   end
 

--- a/lib/puppetdb/parser_helper.rb
+++ b/lib/puppetdb/parser_helper.rb
@@ -41,21 +41,21 @@ module PuppetDB::ParserHelper
       # Array#include? only matches on values of the same type, so if we find
       # a matching string, it's not a nested query.
       name, value = if facts.include?(fact['name'])
-                [fact['name'], fact['value']]
-              else
-                # Find the set of keys where the first value is the fact name
-                nested_keys = facts.select do |x|
-                  x.is_a?(Array) && x.first == fact['name']
-                end.flatten
+                      [fact['name'], fact['value']]
+                    else
+                      # Find the set of keys where the first value is the fact name
+                      nested_keys = facts.select do |x|
+                        x.is_a?(Array) && x.first == fact['name']
+                      end.flatten
 
-                # Join all the key names together with an underscore to give
-                # us a unique name, and then send all the keys but the fact
-                # name (which was already queried out) to extract_nested_fact
-                [
-                  nested_keys.join("_"),
-                  extract_nested_fact([fact], nested_keys[1..-1]).first
-                ]
-              end
+                      # Join all the key names together with an underscore to give
+                      # us a unique name, and then send all the keys but the fact
+                      # name (which was already queried out) to extract_nested_fact
+                      [
+                        nested_keys.join("_"),
+                        extract_nested_fact([fact], nested_keys[1..-1]).first
+                      ]
+                    end
 
       if ret.include? fact['certname']
         ret[fact['certname']][name] = value

--- a/spec/functions/query_facts_spec.rb
+++ b/spec/functions/query_facts_spec.rb
@@ -12,4 +12,14 @@ describe 'query_facts' do
       ]
     should run.with_params('', ['ipaddress']).and_return('apache4.puppetexplorer.io' => { 'ipaddress' => '172.31.6.80' })
   end
+
+  it do
+    PuppetDB::Connection.any_instance.expects(:query)
+      .with(:facts, ['or', ['=', 'name', 'ipaddress'], ['=', 'name', 'network_eth0']], {:extract => [:certname, :name, :value]})
+      .returns [
+        { 'certname' => 'apache4.puppetexplorer.io', 'environment' => 'production', 'name' => 'ipaddress', 'value' => '172.31.6.80' },
+        { 'certname' => 'apache4.puppetexplorer.io', 'environment' => 'production', 'name' => 'network_eth0', 'value' => '172.31.0.0' }
+      ]
+    should run.with_params('', ['ipaddress', 'network_eth0']).and_return('apache4.puppetexplorer.io' => { 'ipaddress' => '172.31.6.80', 'network_eth0' => '172.31.0.0' })
+  end
 end

--- a/spec/functions/query_facts_spec.rb
+++ b/spec/functions/query_facts_spec.rb
@@ -22,4 +22,33 @@ describe 'query_facts' do
       ]
     should run.with_params('', ['ipaddress', 'network_eth0']).and_return('apache4.puppetexplorer.io' => { 'ipaddress' => '172.31.6.80', 'network_eth0' => '172.31.0.0' })
   end
+
+  context 'with a nested fact parameter' do
+    it do
+      PuppetDB::Connection.any_instance.expects(:query)
+        .with(:facts, ['or', ['=', 'name', 'ipaddress'], ['=', 'name', 'networking']], {:extract => [:certname, :name, :value]})
+        .returns [
+          { 'certname' => 'apache4.puppetexplorer.io', 'environment' => 'production', 'name' => 'ipaddress', 'value' => '172.31.6.80' },
+          {
+            'certname' => 'apache4.puppetexplorer.io',
+            'environment' => 'production',
+            'name' => 'networking',
+            'value' => {
+              'interfaces' => {
+                'eth0' => {
+                  'ip' => '172.31.6.80',
+                  'network' => '172.31.0.0',
+                },
+                'eth1' => {
+                  'ip' => '172.32.6.80',
+                  'network' => '172.32.0.0',
+                },
+                'bond0' => {},
+              }
+            }
+          }
+        ]
+      should run.with_params('', ['ipaddress', 'networking.interfaces.eth0.ip']).and_return('apache4.puppetexplorer.io' => { 'ipaddress' => '172.31.6.80', 'networking_interfaces_eth0_ip' => '172.31.6.80' })
+    end
+  end
 end

--- a/spec/functions/query_nodes_spec.rb
+++ b/spec/functions/query_nodes_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby -S rspec
 
 require 'spec_helper'
+require 'puppetdb/connection'
 
 describe 'query_nodes' do
   context 'without fact parameter' do
@@ -18,6 +19,31 @@ describe 'query_nodes' do
         .with(:facts, ['and', ['in', 'certname', ['extract', 'certname', ['select_fact_contents', ['and', ['=', 'path', ['hostname']], ['=', 'value', 'apache4']]]]], ['or', ['=', 'name', 'ipaddress']]], :extract => :value)
         .returns [ { 'value' => '172.31.6.80' } ]
       should run.with_params('hostname="apache4"', 'ipaddress').and_return(['172.31.6.80'])
+    end
+  end
+
+  context 'with a nested facter paramter' do
+    it do
+      PuppetDB::Connection.any_instance.expects(:query)
+        .with(:facts, ['and', ['in', 'certname', ['extract', 'certname', ['select_fact_contents', ['and', ['=', 'path', ['hostname']], ['=', 'value', 'apache4']]]]], ['or', ['=', 'name', 'networking']]], :extract => :value)
+        .returns [
+          {
+            'value' => {
+              'interfaces' => {
+                'eth0' => {
+                  'ip' => '172.31.6.80',
+                  'network' => '172.31.0.0',
+                },
+                'eth1' => {
+                  'ip' => '172.32.6.80',
+                  'network' => '172.32.0.0',
+                },
+                'bond0' => {},
+              }
+            }
+          }
+        ]
+      should run.with_params('hostname="apache4"', ['networking', 'interfaces', 'eth1', 'ip']).and_return(['172.32.6.80'])
     end
   end
 end

--- a/spec/functions/query_nodes_spec.rb
+++ b/spec/functions/query_nodes_spec.rb
@@ -46,4 +46,29 @@ describe 'query_nodes' do
       should run.with_params('hostname="apache4"', 'networking.interfaces.eth1.ip').and_return(['172.32.6.80'])
     end
   end
+
+  context 'with a missing nested fact parameter' do
+    it do
+      PuppetDB::Connection.any_instance.expects(:query)
+        .with(:facts, ['and', ['in', 'certname', ['extract', 'certname', ['select_fact_contents', ['and', ['=', 'path', ['hostname']], ['=', 'value', 'apache4']]]]], ['or', ['=', 'name', 'networking']]], :extract => :value)
+        .returns [
+          {
+            'value' => {
+              'interfaces' => {
+                'eth0' => {
+                  'ip' => '172.31.6.80',
+                  'network' => '172.31.0.0',
+                },
+                'eth1' => {
+                  'ip' => '172.32.6.80',
+                  'network' => '172.32.0.0',
+                },
+                'bond0' => {},
+              }
+            }
+          }
+        ]
+      should run.with_params('hostname="apache4"', 'networking.interfaces.missing_interface.ip').and_return([nil])
+    end
+  end
 end

--- a/spec/functions/query_nodes_spec.rb
+++ b/spec/functions/query_nodes_spec.rb
@@ -22,7 +22,7 @@ describe 'query_nodes' do
     end
   end
 
-  context 'with a nested facter paramter' do
+  context 'with a nested fact parameter' do
     it do
       PuppetDB::Connection.any_instance.expects(:query)
         .with(:facts, ['and', ['in', 'certname', ['extract', 'certname', ['select_fact_contents', ['and', ['=', 'path', ['hostname']], ['=', 'value', 'apache4']]]]], ['or', ['=', 'name', 'networking']]], :extract => :value)
@@ -43,7 +43,7 @@ describe 'query_nodes' do
             }
           }
         ]
-      should run.with_params('hostname="apache4"', ['networking', 'interfaces', 'eth1', 'ip']).and_return(['172.32.6.80'])
+      should run.with_params('hostname="apache4"', 'networking.interfaces.eth1.ip').and_return(['172.32.6.80'])
     end
   end
 end

--- a/spec/unit/puppetdb/parser_spec.rb
+++ b/spec/unit/puppetdb/parser_spec.rb
@@ -215,10 +215,22 @@ describe PuppetDB::Parser do
         { 'certname' => 'ip-172-31-45-32.eu-west-1.compute.internal', 'environment' => 'production', 'name' => 'fqdn', 'value' => 'ip-172-31-45-32.eu-west-1.compute.internal' },
         { 'certname' => 'ip-172-31-33-234.eu-west-1.compute.internal', 'environment' => 'production', 'name' => 'fqdn', 'value' => 'ip-172-31-33-234.eu-west-1.compute.internal' },
         { 'certname' => 'ip-172-31-5-147.eu-west-1.compute.internal', 'environment' => 'production', 'name' => 'fqdn', 'value' => 'ip-172-31-5-147.eu-west-1.compute.internal' }
-      ]).should eq(
+      ], ['kernel', 'fqdn']).should eq(
         'ip-172-31-45-32.eu-west-1.compute.internal' => { 'kernel' => 'Linux', 'fqdn' => 'ip-172-31-45-32.eu-west-1.compute.internal' },
         'ip-172-31-33-234.eu-west-1.compute.internal' => { 'kernel' => 'Linux', 'fqdn' => 'ip-172-31-33-234.eu-west-1.compute.internal' },
         'ip-172-31-5-147.eu-west-1.compute.internal' => { 'kernel' => 'Linux', 'fqdn' => 'ip-172-31-5-147.eu-west-1.compute.internal' }
+      )
+    end
+
+    it 'should handle nested facts' do
+      parser.facts_hash([
+        { 'certname' => 'ip-172-31-45-32.eu-west-1.compute.internal', 'environment' => 'production', 'name' => 'kernel', 'value' => 'Linux' },
+        { 'certname' => 'ip-172-31-33-234.eu-west-1.compute.internal', 'environment' => 'production', 'name' => 'kernel', 'value' => 'Linux' },
+        { 'certname' => 'ip-172-31-45-32.eu-west-1.compute.internal', 'environment' => 'production', 'name' => 'networking', 'value' => { 'interfaces' => { 'eth0' => { 'ip' => '172.31.45.32' } } } },
+        { 'certname' => 'ip-172-31-33-234.eu-west-1.compute.internal', 'environment' => 'production', 'name' => 'networking', 'value' => { 'interfaces' => { 'eth0' => { 'ip' => '172.31.33.234' } } } },
+      ], ['kernel', ['networking', 'interfaces', 'eth0', 'ip']]).should eq(
+        'ip-172-31-45-32.eu-west-1.compute.internal' => { 'kernel' => 'Linux', 'networking_interfaces_eth0_ip' => '172.31.45.32' },
+        'ip-172-31-33-234.eu-west-1.compute.internal' => { 'kernel' => 'Linux', 'networking_interfaces_eth0_ip' => '172.31.33.234' },
       )
     end
   end


### PR DESCRIPTION
Facter 3 introduced a lot of facts that are large hashes, which gets
difficult to work with in Puppet when using query_nodes or query_facts.
The types don't seem to coerce just right, so you'll get back a hash of
values with the type `Runtime[ruby string]`, which Puppet doesn't know
what to do with at the manifest level.

This PR introduces the ability to pass a dotted fact to query for nested facts. You can do something like:
```puppet
  query_nodes('<node_query>', 'networking.interfaces.eth0.network')
```
to get back eth0 network for all matching nodes.

It's implemented for both query_nodes and query_facts in this PR.