### PR TITLE
Incorrect memo processing in reduce()

### DIFF
--- a/lib/puppet/parser/functions/query_resources.rb
+++ b/lib/puppet/parser/functions/query_resources.rb
@@ -68,6 +68,7 @@ EOT
     results.reduce({}) do |ret, resource|
       ret[resource['certname']] = [] unless ret.key? resource['certname']
       ret[resource['certname']] << resource
+      ret
     end
   else
     results


### PR DESCRIPTION
The last statement does not properly return memo value in reduce() block leading to "unknown .key? method" errors on next iterations.

NOTE: I have not tested particular PR code, but it's the same simple change I have made locally.