### PR TITLE
fix 2.2.0 regression on using a regexp pattern in facts query

### DIFF
--- a/lib/puppetdb/parser_helper.rb
+++ b/lib/puppetdb/parser_helper.rb
@@ -46,7 +46,10 @@ module PuppetDB::ParserHelper
     fact_hash.reduce({}) do |ret, fact|
       # Array#include? only matches on values of the same type, so if we find
       # a matching string, it's not a nested query.
-      name, value = if facts.include?(fact['name']) || facts == [:all]
+      name, value = if facts.include?(fact['name']) || facts == [:all] ||
+                      # in case a regex pattern is used in the facts query
+                      facts.index{ |factname| factname =~ /^\/(.+)\/$/ && Regexp.new(factname.match(/^\/(.+)\/$/)[1]).match(fact['name']) }
+
                       [fact['name'], fact['value']]
                     else
                       # Find the set of keys where the first value is the fact name


### PR DESCRIPTION
This PR fixes a regression that has been introduced by the nested-keys-facts-patch included in 2.2.0 release. 

That patch causes a program abort as soon as a pattern (/xxx/) is used in ```query_facts()``` which can not be handled by ```extract_nested_fact()``` in ```PuppetDB::ParserHelper```.

The PR corrects this by extending ```facts_hash()``` to not call ```extract_nested_fact()``` in that case.