### PR TITLE
README: fix ruby example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Ruby
 
     $ irb> require 'puppet/face'
       irb> Puppet.initialize_settings
-      irb> Puppet::Face[:query, :current].nodes('(Package["mysql-server"] and architecture=amd64)')
+      irb> Puppet::Face[:puppetdbquery, :current].nodes('(Package["mysql-server"] and architecture=amd64)')
 
 Puppet functions
 ----------------


### PR DESCRIPTION
As face has been renamed in 2c744337432e5601114ad64e59c335ff25b0bc1d.