### PR TITLE
Get rid of deprecated URI.escape function

### DIFF
--- a/lib/puppetdb/connection.rb
+++ b/lib/puppetdb/connection.rb
@@ -60,7 +60,7 @@ EOT
     end
 
     uri = "/pdb/query/#{version}/#{endpoint}"
-    uri += URI.escape "?query=#{query.to_json}" unless query.nil? || query.empty?
+    uri += URI.encode_www_form_component "?query=#{query.to_json}" unless query.nil? || query.empty?
 
     debug("PuppetDB query: #{query.to_json}")
 

--- a/lib/puppetdb/connection.rb
+++ b/lib/puppetdb/connection.rb
@@ -60,7 +60,7 @@ EOT
     end
 
     uri = "/pdb/query/#{version}/#{endpoint}"
-    uri += URI.encode_www_form_component "?query=#{query.to_json}" unless query.nil? || query.empty?
+    uri += "?query=#{URI.encode_www_form_component(query.to_json)}" unless query.nil? || query.empty?
 
     debug("PuppetDB query: #{query.to_json}")
 


### PR DESCRIPTION
URI.escape has been removed as of Ruby 3 (Puppet8).