### PR TITLE
Improvement of Nested Fact Handling in facts_hash

### DIFF
--- a/lib/puppet/functions/query_facts.rb
+++ b/lib/puppet/functions/query_facts.rb
@@ -32,7 +32,7 @@ Puppet::Functions.create_function('query_facts')  do
     uri = URI(Puppet::Util::Puppetdb.config.server_urls.first)
     puppetdb = PuppetDB::Connection.new(uri.host, uri.port, uri.scheme == 'https')
     parser = PuppetDB::Parser.new
-    query = parser.facts_query query, facts_for_query if query.is_a? String
+    query = parser.facts_query query, facts_for_query.uniq if query.is_a? String
     parser.facts_hash(puppetdb.query(:facts, query, :extract => [:certname, :name, :value]), facts)
   end
 end

--- a/lib/puppetdb/parser_helper.rb
+++ b/lib/puppetdb/parser_helper.rb
@@ -70,15 +70,17 @@ module PuppetDB::ParserHelper
                         end
                       end
 
-                      # Return nil to skip the default assignment (handled by nested results)
-                      next ret
+                      ret
                     end
 
-      if ret.include? fact['certname']
-        ret[fact['certname']][name] = value
-      else
-        ret[fact['certname']] = { name => value }
+      if name && value
+        if ret.include? fact['certname']
+          ret[fact['certname']][name] = value
+        else
+          ret[fact['certname']] = { name => value }
+        end
       end
+
       ret
     end
   end


### PR DESCRIPTION
In the `facts_hash` method, when encountering multiple facts with nested elements sharing the same base name (e.g., multiple facts related to networking), the current logic concatenated the keys to make them unique (e.g., "networking_hostname_networking_fqdn" instead of "networking_hostname" and "networking_fqdn"). This behaviour was incorrect as it treated them as a single fact instead of separate ones.

Improvements to fact queries:

* [`lib/puppet/functions/query_facts.rb`](diffhunk://#diff-bc925953b691f8f792eed7ff109329153ce5d17bcc9d0c9b7a0de1b64c3b686eL35-R35): Modified the `query_facts` method to ensure that the `facts_for_query` array contains only unique elements.

Enhancements to nested keys processing:

* [`lib/puppetdb/parser_helper.rb`](diffhunk://#diff-5a0b54276b918bb6e417f38d8cc6aa17bf1328916380464b87bf62ebe4184ddcL55-R76): Updated the `facts_hash` method to group nested keys individually, create unique names, and return nested results as an array of hashes to be added individually. This change ensures that nested results are handled properly and avoids redundant assignments.